### PR TITLE
Tickfloat

### DIFF
--- a/market.go
+++ b/market.go
@@ -30,7 +30,7 @@ func (c BTCMarketsClient) DefaultTick() (tr TickResponse, err error) {
 }
 
 //Tick get current tick details
-func (c BTCMarketsClient) Tick(CurrencyFrom, CurrencyTo string) (tr ccg.Tick, err error) {
+func (c BTCMarketsClient) Tick(CurrencyFrom, CurrencyTo string) (tr ccg.TickFloat, err error) {
 	all, err := getBody(c.Domain + "/market/" + CurrencyTo + "/" + CurrencyFrom + "/tick")
 	if err != nil {
 		return

--- a/util.go
+++ b/util.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -66,7 +65,6 @@ func (c BTCMarketsClient) signAnd(URI string, i interface{}, do string) ([]byte,
 	} else {
 		body = []byte("")
 	}
-	spew.Dump(i)
 	client := http.Client{}
 	now, signature := c.sign(URI, string(body))
 	URL := c.Domain + URI


### PR DESCRIPTION
Use the new `TickFloat` type in [cryptoclientgo](https://github.com/RyanCarrier/cryptoclientgo/pull/1/files) for JSON API responses that contain floats (e.g. `/market/*/*/tick`)

Remove `spew`